### PR TITLE
Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 node_modules

--- a/visual-editor/src/components/Preview/Preview.tsx
+++ b/visual-editor/src/components/Preview/Preview.tsx
@@ -43,17 +43,21 @@ export function Preview({ data, previewUrl }: PreviewProps) {
     }
 
     // On écrit le contenu dans l'iframe
-    const iframeDocument = iframe.current!.contentDocument!
-    iframeDocument.open()
-    iframeDocument.write(await r.text())
-    iframeDocument.close()
-    const root = iframeDocument.querySelector('#ve-components') as HTMLElement
-    initialHTML.current = Array.from(root.children).reduce(
-      (acc, v, k) => ({ ...acc, [data[k]!._id]: v.outerHTML }),
-      {}
-    )
-    root.innerHTML = ''
-    setIframeRoot(root)
+    try {
+      const iframeDocument = iframe.current!.contentDocument!
+      iframeDocument.open()
+      iframeDocument.write(await r.text())
+      iframeDocument.close()
+      const root = iframeDocument.querySelector('#ve-components') as HTMLElement
+      initialHTML.current = Array.from(root.children).reduce(
+          (acc, v, k) => ({ ...acc, [data[k]!._id]: v.outerHTML }),
+          {}
+      )
+      root.innerHTML = ''
+      setIframeRoot(root)
+    } catch (e) {
+      return
+    }
   }, [])
 
   const previewMode = usePreviewMode()

--- a/visual-editor/src/fields/TextAlign.tsx
+++ b/visual-editor/src/fields/TextAlign.tsx
@@ -30,14 +30,14 @@ const Component: FieldComponent<FieldArgs, string> = ({
   options,
 }) => {
   const alignements = Object.keys(AlignmentIcons) as FieldValue[]
-  const id = useUniqId()
+  const id = useUniqId('textaligninput')
   return (
     <Field label={options.label}>
       <AlignmentButtons>
         {alignements.map((alignment) => (
           <AlignmentButton<FieldValue>
             key={alignment}
-            name={id}
+            id={id}
             value={alignment}
             checked={value === alignment}
             onChange={onChange}

--- a/visual-editor/src/fields/shared/AlignmentButton.tsx
+++ b/visual-editor/src/fields/shared/AlignmentButton.tsx
@@ -1,7 +1,6 @@
 import type { FunctionComponent } from 'react'
 import styled from '@emotion/styled'
 import { capitalize } from 'src/functions/string'
-import { prevent } from 'src/functions/functions'
 
 type Props<T extends unknown> = {
   value: T

--- a/visual-editor/src/fields/shared/AlignmentButton.tsx
+++ b/visual-editor/src/fields/shared/AlignmentButton.tsx
@@ -8,7 +8,7 @@ type Props<T extends unknown> = {
   checked: boolean
   icon: FunctionComponent
   onChange: (v: T) => void
-  name?: string
+  id?: string
 }
 
 export function AlignmentButton<T extends unknown>({


### PR DESCRIPTION
Le commit 235d963 corrige l'erreur erreur en console Uncaught (in promise) TypeError ...
![visual-editor-error](https://user-images.githubusercontent.com/18441194/175531719-5a9e0c04-e432-47d6-a726-334bfab8f3a2.png)

En corrigeant le 'TypeError', le 'Warning' que l'on voit dans la capture disparait, donc je ne sais pas sur de mon fix.

Pour l'autre correction parle d'elle même et fait suite à l'issue que j'ai ouverte.