### PR TITLE
add option to choose block position on add. fix #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -76,6 +76,7 @@ You now have a custom element `visual-editor` that you can use to display the ed
   preview="http://localhost:3000/preview"
   iconsUrl="/assets/editor/[name].svg"
   value="[]"
+  blockPositionOnAdd="top"
 ></visual-editor>
 ```
 
@@ -86,6 +87,7 @@ There are multiple mandatory attributes :
 - `preview`, endpoint called to render the preview
 - `iconsUrl`, path used to resolve component icons URL ([name] will be replaced by the ID of the component)
 - `value` (optional), will set the default value for the editor (expect a JSON array)
+- `blockPositionOnAdd` (optional), determine at which position the new block will be added (**top**: before all others blocks or **bottom**: after all others blocks)
 
 The custom element will create a hidden field that will be used to store the data, no need for additional JavaScript you will receive the data when the form is submitted.
 

--- a/visual-editor/README.md
+++ b/visual-editor/README.md
@@ -74,6 +74,7 @@ You now have a custom element `visual-editor` that you can use to display the ed
   preview="http://localhost:3000/preview"
   iconsUrl="/assets/editor/[name].svg"
   value="[]"
+  blockPositionOnAdd="top"
 ></visual-editor>
 ```
 
@@ -84,6 +85,7 @@ There are multiple attributes :
 - `preview`, endpoint called to render the preview
 - `iconsUrl`, path used to resolve component icons URL ([name] will be replaced by the ID of the component)
 - `value` (optional), will set the default value for the editor (expect a JSON array)
+- `blockPositionOnAdd` (optional), determine at which position the new block will be added (**top**: before all others blocks or **bottom**: after all others blocks)
 
 The custom element will create a hidden field that will be used to store the data, no need for additional JavaScript you will receive the data when the form is submitted.
 

--- a/visual-editor/src/VisualEditor.tsx
+++ b/visual-editor/src/VisualEditor.tsx
@@ -113,6 +113,7 @@ export class VisualEditor {
         const data = this.parseValue(this._value)
         const hiddenCategories =
           this.getAttribute('hidden-categories')?.split(';') ?? []
+
         createRoot(this).render(
           <StoreProvider
             data={data}
@@ -126,6 +127,7 @@ export class VisualEditor {
               value={data}
               previewUrl={this.getAttribute('preview') ?? ''}
               iconsUrl={this.getAttribute('iconsUrl') ?? '/'}
+              blockPositionOnAdd={this.getAttribute('blockPositionOnAdd') ?? 'top'}
               name={this.getAttribute('name') ?? ''}
               visible={this.getAttribute('hidden') === null}
               onChange={(value: string) => {
@@ -153,6 +155,7 @@ type VisualEditorProps = {
   previewUrl: string
   name: string
   iconsUrl: string
+  blockPositionOnAdd: string
   visible: boolean
   element: Element
   onChange: (v: string) => void
@@ -164,6 +167,7 @@ export function VisualEditorComponent({
   name,
   element,
   iconsUrl,
+  blockPositionOnAdd,
   visible: visibleProps,
   onChange,
 }: VisualEditorProps) {
@@ -209,6 +213,7 @@ export function VisualEditorComponent({
           onClose={handleClose}
           previewUrl={previewUrl}
           iconsUrl={iconsUrl}
+          blockPositionOnAdd={blockPositionOnAdd}
         />
       </BaseStyles>
       <textarea hidden name={name} value={cleanedData} onChange={doNothing} />

--- a/visual-editor/src/components/Blocs/BlocSelector.tsx
+++ b/visual-editor/src/components/Blocs/BlocSelector.tsx
@@ -74,9 +74,7 @@ export function BlocSelector({ iconsUrl, blockPositionOnAdd }: BlocSelectorProps
                   definition={definitions[key]!}
                   name={key}
                   iconsUrl={iconsUrl}
-                  onClick={() => {
-                    addBlock(key, blockPositionOnAdd)
-                  }}
+                  onClick={() => addBlock(key, blockPositionOnAdd)}
                 />
               ))}
           </BlocSelectorGrid>

--- a/visual-editor/src/components/Blocs/BlocSelector.tsx
+++ b/visual-editor/src/components/Blocs/BlocSelector.tsx
@@ -17,9 +17,10 @@ const ALL_TAB = 'Tous les blocs'
 
 type BlocSelectorProps = {
   iconsUrl: string
+  blockPositionOnAdd: string
 }
 
-export function BlocSelector({ iconsUrl }: BlocSelectorProps) {
+export function BlocSelector({ iconsUrl, blockPositionOnAdd }: BlocSelectorProps) {
   const isVisible = useBlocSelectionVisible()
   const setBlockIndex = useSetBlockIndex()
   const [search, setSearch] = useState('')
@@ -73,7 +74,9 @@ export function BlocSelector({ iconsUrl }: BlocSelectorProps) {
                   definition={definitions[key]!}
                   name={key}
                   iconsUrl={iconsUrl}
-                  onClick={() => addBlock(key)}
+                  onClick={() => {
+                    addBlock(key, blockPositionOnAdd)
+                  }}
                 />
               ))}
           </BlocSelectorGrid>

--- a/visual-editor/src/components/Layout.tsx
+++ b/visual-editor/src/components/Layout.tsx
@@ -18,9 +18,10 @@ type LayoutProps = {
   previewUrl?: string
   onClose: () => void
   iconsUrl: string
+  blockPositionOnAdd: string
 }
 
-export function Layout({ data, previewUrl, onClose, iconsUrl }: LayoutProps) {
+export function Layout({ data, previewUrl, onClose, iconsUrl, blockPositionOnAdd }: LayoutProps) {
   const [sidebarCollapsed, toggleSidebar] = useToggle(false)
   const showResizeControl = !sidebarCollapsed
   return (
@@ -39,7 +40,7 @@ export function Layout({ data, previewUrl, onClose, iconsUrl }: LayoutProps) {
           onClick={toggleSidebar}
         />
         {showResizeControl && <ResizeBar />}
-        <BlocSelector iconsUrl={iconsUrl} />
+        <BlocSelector iconsUrl={iconsUrl} blockPositionOnAdd={blockPositionOnAdd} />
         <RollbackMessage />
       </Wrapper>
     </>

--- a/visual-editor/src/store.tsx
+++ b/visual-editor/src/store.tsx
@@ -257,14 +257,15 @@ export function useTemplates(): EditorComponentTemplate[] {
 
 export function useAddBlock() {
   const insertData = useInsertData()
-  const blockIndex = useStore((state) => state.addBlockIndex) || 0
+  const blockIndex = useStore((state) => state.data.length) || 0
+
   const definitions = useDefinitions()
   const setBlockIndex = useSetBlockIndex()
   return useCallback(
-    (blocName: string) => {
+    (blocName: string, blockPosition: string) => {
       insertData(
         blocName,
-        blockIndex,
+        blockPosition === 'bottom' ? blockIndex : 0,
         fillDefaults({}, definitions[blocName]!.fields)
       )
       setBlockIndex(null)


### PR DESCRIPTION
J'ai ajouté l'option afin de pouvoir choisir si l'on souhaite ajouter les blocs les uns à la suite des autres ou en haut.
Pour utiliser l'option il faut ajouter un attribute **blockPositionOnAdd** sur le custom element, qui prend soit "bottom" ou "top" (configurer sur "top" par défaut).
J'ai pas gérer d'enum pour la position. Je check si c'est === "bottom" dans ce cas c'est en bas sinon c'est en haut.

N'hésite pas à me dire si quelque chose n'est pas bon.

PS: J'ai pas réussi a run les tests e2e sur ma machine, donc je sais pas si ils passent toujours mais normalement oui :p